### PR TITLE
Fix out of the box local dev build

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -2,6 +2,8 @@ FROM python:alpine3.6
 
 ENV PYTHONUNBUFFERED 1
 
+RUN pip install --upgrade pip
+
 RUN apk add --no-cache shadow
 RUN useradd --user-group --create-home --home-dir /flask --shell /bin/false flask
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -9,10 +9,9 @@ RUN apk add --no-cache linux-headers make gcc musl-dev libxml2-dev libxslt-dev l
 
 WORKDIR /flask/src
 
+COPY ./requirements.txt requirements.txt
 COPY ./requirements-dev.txt requirements-dev.txt
 RUN pip install --no-cache-dir -r requirements-dev.txt
-
-COPY ./requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 USER flask


### PR DESCRIPTION
Currently the out of the box build docker-compose up --build breaks for the following reason:
- old pip version (fixed with a pip install --upgrade)
- requirements-dev.txt references requirements.txt which isn't copied to the folder yet (fixed by reordering copy)